### PR TITLE
exclude build.metadata generated by the pom manipulator plugin from the ...

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -264,6 +264,7 @@
                         </goals>
                         <configuration>
                             <excludes>
+                                <exclude>build.metadata</exclude>
                                 <exclude>**/*.iml</exclude>
                                 <exclude>src/docs/**</exclude>
                                 <exclude>**/stty-output-*.txt</exclude>


### PR DESCRIPTION
...apache-rat-plugin, as it thinks it contains an Unapproved licenses
