### PR TITLE
Fix for PME and RAT plugin incompatibility 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -265,6 +265,7 @@
                         <configuration>
                             <excludes>
                                 <exclude>build.metadata</exclude>
+                                <exclude>settings.xml</exclude>
                                 <exclude>**/*.iml</exclude>
                                 <exclude>src/docs/**</exclude>
                                 <exclude>**/stty-output-*.txt</exclude>

--- a/pom.xml
+++ b/pom.xml
@@ -264,6 +264,7 @@
                         </goals>
                         <configuration>
                             <excludes>
+                                <exclude>build.metadata</exclude>
                                 <exclude>**/*.iml</exclude>
                                 <exclude>src/docs/**</exclude>
                                 <exclude>**/stty-output-*.txt</exclude>


### PR DESCRIPTION
PME drops two files into the root build directory at the initalize lifecycle, the RAT plugin can't parse a license from them and causes the build to fail